### PR TITLE
feat: fake url

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,43 @@ This extension is a Chromium based extension since this platform seems the be th
 The whole project is a hack. It only points out the current problems within dApp ecosystem in regular Web2 browsers,
 but on the other hand its goal to show alternatives how to build a real Web3 environment for dApps in structural sense.
 
+## Fake URL
+
+There is a need to separate dApp context from the user context in order to restrict dApp actions work with keys and resources of the user.
+In a web3 environment the browser acts like a backend server. To accomplish this desired role it has to introduce endpoints that dApps can interact with.
+These endpoints are called `Fake URLs`.
+The naming came from these URLs should not point to any real existing endpoint that a common server could serve,
+so the host part of the URL (probably) is not the real destination.
+
+Web applications can make requests to other decentralized application APIs in the scope of the user
+by aiming its corresponding Fake URLs that basically make redirect to these real API address.
+It is neccessary, because the targeted services may need additional headers and keys to perform the action that **should not be handled on dApp side**.
+The extension can keep this keys and configurations on the side of the user
+and it does not expose the secrets to the applications that initialize the call.
+In this sense it also works like a `proxy`.
+
+During the redirect, the extension can create separated context for `root content IDs` and perform the action according to that.
+(E.g. restrict calls towards the targeted service, cache the returned cookies from the response in the content context, etc.)
+This architecture also allows for used decentralized services to change its default URLs to any arbitrary one,
+meanwhile dApps do not have to guess this address.
+For example Bee client has default `http://localhost:1633`, user can change it to any other port or even other gateway host,
+the dApps will call it in the same way.
+
+### Callable Endpoints
+
+For any action the Fake URL host is `http://localhost:1633`.
+As it is written earlier, it is not the address of the Bee client,
+it is just a reserved host address that the extension took and built its Fake URL paths on it.
+If the user changes their Bee API address, these callings still remain the same from dApp side.
+
+- `http://localhost:1633/fake-url/bzz/*` - `BZZ protocol` redirects to this fake URL, thereby in `*` can be not only content reference with its path, but any BZZ protocol compatible reference. It will be redirected to `bzz` endpoint of the Bee client.
+- `http://localhost:1633/fake-url/bee-api/*` - it will be forwarded to the Bee API. `*` has to be valid Bee API path
+
 ## Custom Protocol
 
-Only supported Swarm protocol currently is `bzz`. It makes a redirect to the BZZ endpoint of the Bee node(, which is fixed `localhost:1633`, will be changeable later).
-There will be need for other Swarm specific protocols, which handles different type of feeds and mutable content.
+Only supported Swarm protocol currently is `bzz` (in HTML files `web+bzz`).
+It makes a redirect to the BZZ endpoint of the Bee node by calling its corresponding Fake URL.
+There will be need for other Swarm specific protocols (or extend the current one), which handles different type of feeds and mutable content.
 
 The extension currently [injects a script](src/contentscript/index.ts) on document load in order to dApp pages could refer other P2P resources.
 It is injected to every page basically, because in [manifest.json](manifest.json) you need to define where the injection happens by a fixed pattern for URLs and the host can be determenistic and changeable in this case.

--- a/src/background/listener/bee-api.listener.ts
+++ b/src/background/listener/bee-api.listener.ts
@@ -41,23 +41,6 @@ export class BeeApiListener {
       ['blocking'],
     )
 
-    // Redirects 'web+bzz://' custom protocol
-    chrome.webRequest.onBeforeRequest.addListener(
-      details => {
-        const urlArray = details.url.split('web%2Bbzz%3A%2F%2F')
-
-        // no match
-        if (urlArray.length === 1) return
-
-        const redirectUrl = `${this._beeApiUrl}/bzz/${urlArray[1]}`
-        console.log(`web+bzz redirect to ${redirectUrl} from ${details.url}`)
-
-        return { redirectUrl }
-      },
-      { urls: [`${fakeUrl.webBzzProtocol}/*`] },
-      ['blocking'],
-    )
-
     // Used to load page resources like images
     chrome.webRequest.onBeforeRequest.addListener(
       details => {

--- a/src/background/listener/bee-api.listener.ts
+++ b/src/background/listener/bee-api.listener.ts
@@ -58,7 +58,6 @@ export class BeeApiListener {
       ['blocking'],
     )
 
-    // Redirects 'bzz-resource=<content_hash>'  to '<gateway>/bzz/<content_hash>
     // Used to load page resources like images
     chrome.webRequest.onBeforeRequest.addListener(
       details => {
@@ -71,6 +70,22 @@ export class BeeApiListener {
         }
       },
       { urls: [`${fakeUrl.bzzProtocol}/*`] },
+      ['blocking'],
+    )
+
+    // Forward requests to the Bee client with the corresponding keys
+    // TODO add API key here to the request if it will be available in the Bee client
+    chrome.webRequest.onBeforeRequest.addListener(
+      details => {
+        const urlArray = details.url.split(fakeUrl.beeApiAddress)
+        const redirectUrl = `${this._beeApiUrl}${urlArray[1]}`
+        console.log(`Bee API client request redirect to ${redirectUrl} from ${details.url}`)
+
+        return {
+          redirectUrl,
+        }
+      },
+      { urls: [`${fakeUrl.beeApiAddress}*`] },
       ['blocking'],
     )
   }

--- a/src/background/listener/bee-api.listener.ts
+++ b/src/background/listener/bee-api.listener.ts
@@ -1,4 +1,5 @@
 import { StoreObserver, getItem } from '../../utils/storage'
+import { fakeUrl } from '../../utils/fake-url'
 export class BeeApiListener {
   private _beeApiUrl: string
 
@@ -49,11 +50,11 @@ export class BeeApiListener {
         if (urlArray.length === 1) return
 
         const redirectUrl = `${this._beeApiUrl}/bzz/${urlArray[1]}`
-        console.log(`BZZ redirect to ${redirectUrl} from ${details.url}`)
+        console.log(`web+bzz redirect to ${redirectUrl} from ${details.url}`)
 
         return { redirectUrl }
       },
-      { urls: [`${this._beeApiUrl}/dapp-request?bzz-address=*`] },
+      { urls: [`${fakeUrl.webBzzProtocol}/*`] },
       ['blocking'],
     )
 
@@ -61,15 +62,15 @@ export class BeeApiListener {
     // Used to load page resources like images
     chrome.webRequest.onBeforeRequest.addListener(
       details => {
-        const urlArray = details.url.split('bzz-resource=')
+        const urlArray = details.url.split(`${fakeUrl.bzzProtocol}/`)
         const redirectUrl = `${this._beeApiUrl}/bzz/${urlArray[1]}`
-        console.log(`BZZ resource redirect to ${redirectUrl} from ${details.url}`)
+        console.log(`bzz redirect to ${redirectUrl} from ${details.url}`)
 
         return {
           redirectUrl,
         }
       },
-      { urls: [`${this._beeApiUrl}/dapp-request?bzz-resource=*`] },
+      { urls: [`${fakeUrl.bzzProtocol}/*`] },
       ['blocking'],
     )
   }

--- a/src/contentscript/document-idle/bzz-handler.ts
+++ b/src/contentscript/document-idle/bzz-handler.ts
@@ -1,3 +1,5 @@
+import { web2HelperContent } from '../web2-helper.content'
+
 // Unfortunately I didn't find better solution first to register custom protocols in chromium based browsers
 // So his script will solve this problem as is in order to use swarm protocols
 // web+ prefix is needed for custom protocols
@@ -12,8 +14,6 @@ window.addEventListener(
   false,
 )
 
-const dappRequestUrl = 'http://localhost:1633/dapp-request'
-
 const images = document.images
 const iframes = document.getElementsByTagName('iframe')
 const links = document.getElementsByTagName('a')
@@ -23,7 +23,7 @@ for (const srcElement of srcElements) {
   const bzzElementSrc = srcElement.src.split('web+bzz://')
 
   if (bzzElementSrc.length === 2) {
-    srcElement.src = `${dappRequestUrl}?bzz-resource=${bzzElementSrc[1]}`
+    srcElement.src = web2HelperContent.bzzAddress(bzzElementSrc[1])
   }
 }
 //change link sources
@@ -31,6 +31,6 @@ for (const link of links) {
   const bzzLinkHref = link.href.split('web+bzz://')
 
   if (bzzLinkHref.length === 2) {
-    link.href = `${dappRequestUrl}?bzz-resource=${bzzLinkHref[1]}`
+    link.href = web2HelperContent.bzzAddress(bzzLinkHref[1])
   }
 }

--- a/src/contentscript/document-idle/bzz-handler.ts
+++ b/src/contentscript/document-idle/bzz-handler.ts
@@ -23,7 +23,7 @@ for (const srcElement of srcElements) {
   const bzzElementSrc = srcElement.src.split('web+bzz://')
 
   if (bzzElementSrc.length === 2) {
-    srcElement.src = web2HelperContent.bzzAddress(bzzElementSrc[1])
+    srcElement.src = web2HelperContent.fakeBzzAddress(bzzElementSrc[1])
   }
 }
 //change link sources
@@ -31,6 +31,6 @@ for (const link of links) {
   const bzzLinkHref = link.href.split('web+bzz://')
 
   if (bzzLinkHref.length === 2) {
-    link.href = web2HelperContent.bzzAddress(bzzLinkHref[1])
+    link.href = web2HelperContent.fakeBzzAddress(bzzLinkHref[1])
   }
 }

--- a/src/contentscript/swarm-library/index.ts
+++ b/src/contentscript/swarm-library/index.ts
@@ -1,7 +1,7 @@
-import { Web2HelperInpage } from './web2-helper.inpage'
+import { web2HelperContent } from '../web2-helper.content'
 
 window.swarm = {
-  web2Helper: new Web2HelperInpage(),
+  web2Helper: web2HelperContent,
 }
 
 console.log('window.swarm has been inited')

--- a/src/contentscript/web2-helper.content.ts
+++ b/src/contentscript/web2-helper.content.ts
@@ -5,6 +5,7 @@ import { MessengerInpage } from './swarm-library/messenger.inpage'
 import { fakeUrl } from '../utils/fake-url'
 
 export class Web2HelperContent extends MessengerInpage implements IWeb2HelperMessage {
+  /** The real Bee API address that shouldn't be called directly by dApps */
   public beeApiUrl(): Promise<string> {
     const message: InpageReqMessageFormat<undefined> = {
       key: 'beeApiUrl',
@@ -37,12 +38,31 @@ export class Web2HelperContent extends MessengerInpage implements IWeb2HelperMes
     })
   }
 
-  public webBzzAddress(contentHash: string): string {
-    return `${fakeUrl.webBzzProtocol}/${contentHash}`
+  /**
+   * Fake URL which will be forwarded to `bzz` endpoint of the Bee client
+   *
+   * Currently web+bzz://* references in HTML files will be
+   * forwarded to this address.
+   * Can be placed in src|href tags of DOM elements
+   * It appends the corresponding keys on the requests.
+   *
+   * @param reference requested content hash (with optional `path` and other bzz protocol specific params)
+   * @returns Fake URL pointing to the BZZ endpoint of the Bee client
+   */
+  public fakeBzzAddress(reference: string): string {
+    return `${fakeUrl.bzzProtocol}/${reference}`
   }
 
-  public bzzAddress(contentHash: string): string {
-    return `${fakeUrl.bzzProtocol}/${contentHash}`
+  /**
+   * Fake Bee API URL that appends corresponding keys on requests
+   *
+   * Any Bee API path can be appended to the end of the returned address.
+   * Later could be serve from a protocol like `swarm-bee://*` or `dweb://*.swarm-bee`
+   *
+   * @returns Fake Bee API URL that is directly callable from dApp side
+   */
+  public fakeBeeApiAddress(): string {
+    return fakeUrl.beeApiAddress
   }
 }
 

--- a/src/contentscript/web2-helper.content.ts
+++ b/src/contentscript/web2-helper.content.ts
@@ -1,9 +1,10 @@
-import { IWeb2HelperMessage } from '../../utils/message/web2-helper/web2-helper.message'
-import { InterceptorResMessageFormat, InpageReqMessageFormat } from '../../utils/message/message-handler'
+import { IWeb2HelperMessage } from '../utils/message/web2-helper/web2-helper.message'
+import { InterceptorResMessageFormat, InpageReqMessageFormat } from '../utils/message/message-handler'
 import { nanoid } from 'nanoid'
-import { MessengerInpage } from './messenger.inpage'
+import { MessengerInpage } from './swarm-library/messenger.inpage'
+import { fakeUrl } from '../utils/fake-url'
 
-export class Web2HelperInpage extends MessengerInpage implements IWeb2HelperMessage {
+export class Web2HelperContent extends MessengerInpage implements IWeb2HelperMessage {
   public beeApiUrl(): Promise<string> {
     const message: InpageReqMessageFormat<undefined> = {
       key: 'beeApiUrl',
@@ -35,4 +36,14 @@ export class Web2HelperInpage extends MessengerInpage implements IWeb2HelperMess
       window.postMessage(message, window.location.origin)
     })
   }
+
+  public webBzzAddress(contentHash: string): string {
+    return `${fakeUrl.webBzzProtocol}/${contentHash}`
+  }
+
+  public bzzAddress(contentHash: string): string {
+    return `${fakeUrl.bzzProtocol}/${contentHash}`
+  }
 }
+
+export const web2HelperContent = new Web2HelperContent()

--- a/src/utils/fake-url.ts
+++ b/src/utils/fake-url.ts
@@ -5,8 +5,6 @@ class FakeUrl {
    * */
   private readonly baseUrl: string
 
-  public readonly webBzzProtocol: string
-
   public readonly bzzProtocol: string
 
   /** Append neccessary keys to the Bee client requests in the future */
@@ -19,9 +17,8 @@ class FakeUrl {
     // does not need to change even if the client set other URL for bzz protocol
     // does not change during the workflow
     this.baseUrl = 'http://localhost:1633/fake-url'
-    this.webBzzProtocol = `${this.baseUrl}/web-bzz`
     this.bzzProtocol = `${this.baseUrl}/bzz`
-    this.beeApiAddress = `${this.baseUrl}/bee`
+    this.beeApiAddress = `${this.baseUrl}/bee-api`
   }
 }
 

--- a/src/utils/fake-url.ts
+++ b/src/utils/fake-url.ts
@@ -9,6 +9,9 @@ class FakeUrl {
 
   public readonly bzzProtocol: string
 
+  /** Append neccessary keys to the Bee client requests in the future */
+  public readonly beeApiAddress: string
+
   constructor() {
     // bee default API address, which is reserved on this localhost port number,
     // should not overlap with any other service
@@ -18,6 +21,7 @@ class FakeUrl {
     this.baseUrl = 'http://localhost:1633/fake-url'
     this.webBzzProtocol = `${this.baseUrl}/web-bzz`
     this.bzzProtocol = `${this.baseUrl}/bzz`
+    this.beeApiAddress = `${this.baseUrl}/bee`
   }
 }
 

--- a/src/utils/fake-url.ts
+++ b/src/utils/fake-url.ts
@@ -1,0 +1,24 @@
+/** API endpoints that the extension can serve out */
+class FakeUrl {
+  /**
+   * base for the fake URLs
+   * */
+  private readonly baseUrl: string
+
+  public readonly webBzzProtocol: string
+
+  public readonly bzzProtocol: string
+
+  constructor() {
+    // bee default API address, which is reserved on this localhost port number,
+    // should not overlap with any other service
+    // 'fake-url' part does not exist and should not in the future
+    // does not need to change even if the client set other URL for bzz protocol
+    // does not change during the workflow
+    this.baseUrl = 'http://localhost:1633/fake-url'
+    this.webBzzProtocol = `${this.baseUrl}/web-bzz`
+    this.bzzProtocol = `${this.baseUrl}/bzz`
+  }
+}
+
+export const fakeUrl = new FakeUrl()

--- a/test/bzz-protocol.spec.ts
+++ b/test/bzz-protocol.spec.ts
@@ -50,6 +50,45 @@ describe('BZZ protocol', () => {
     checkJinnIframePage(ref)
   })
 
+  test('Fetch Real Bee API URL', async done => {
+    await page.click('#button-fetch-real-bee-api-url')
+    const placeHolderSelector = '#bee-api-url-placeholder'
+    await page.waitForSelector(placeHolderSelector)
+    const value = await page.$eval(placeHolderSelector, e => e.innerHTML)
+    expect(value).toBe('http://localhost:1633') //default value of Bee API URL in the extension
+
+    done()
+  })
+
+  test('Upload file through Fake URL', async done => {
+    await page.click('#button-upload-fake-url-file')
+    const placeHolderSelector = '#fake-bzz-url-content-1 > a:first-child'
+    await page.waitForSelector(placeHolderSelector)
+    await page.click(placeHolderSelector)
+    const bzzPageTitle = await page.$('h1')
+    expect(bzzPageTitle).toBeTruthy()
+    await page.goBack()
+
+    done()
+  })
+
+  test('Fetch image via Fake URL', async done => {
+    await page.click('#button-fetch-jinn-page')
+    const placeHolderSelector = '#fake-url-fetch-jinn > img:first-child'
+    await page.waitForSelector(placeHolderSelector)
+    const completedImageLoad = await page.evaluate(async placeHolderSelector => {
+      const image = document.querySelector(placeHolderSelector)
+
+      return await new Promise(resolve => {
+        image.addEventListener('load', resolve(true))
+        image.addEventListener('error', resolve(false))
+      })
+    }, placeHolderSelector)
+    expect(completedImageLoad).toBeTruthy()
+
+    done()
+  })
+
   test('click on web+bzz link reference', async () => {
     // perform navigation
     await page.click('#bzz-ext-ref')
@@ -62,10 +101,10 @@ describe('BZZ protocol', () => {
   })
 
   test('reference content with bzz://{content-id} with default search engine Google', async () => {
-    const bzzPage = await global.__BROWSER__.newPage()
-    await bzzPage.goto(bzzReferenceByGoogle(rootFolderReference), { waitUntil: 'networkidle0' })
+    const page = await global.__BROWSER__.newPage()
+    await page.goto(bzzReferenceByGoogle(rootFolderReference), { waitUntil: 'networkidle0' })
 
-    const bzzPageTitle = await bzzPage.$('#first-bzz-page-title')
+    const bzzPageTitle = await page.$('#first-bzz-page-title')
 
     expect(bzzPageTitle).toBeTruthy()
   })

--- a/test/bzz-test-page/index.css
+++ b/test/bzz-test-page/index.css
@@ -1,0 +1,4 @@
+#test-cases,
+#first-bzz-page-title {
+  margin: 24px;
+}

--- a/test/bzz-test-page/index.html
+++ b/test/bzz-test-page/index.html
@@ -4,23 +4,58 @@
 <head>
   <meta charset="utf-8">
   <title>First Direct BZZ address</title>
+  <link rel="stylesheet" href="index.css">
+  <script src="https://unpkg.com/@ethersphere/bee-js/dist/index.browser.min.js"></script>
+  <script src="index.js"></script>
 </head>
 
 <body>
   <h1 id="first-bzz-page-title">
     Let's roll!
   </h1>
-  <h3>Local Iframe</h3>
-  <iframe id="localhost-inner-ref" src="jinn-page/index.html"></iframe>
-  <h3>External Iframe refer by BZZ protocol</h3>
-  <iframe id="bzz-iframe" src="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be"></iframe>
-  <h3>Same External Iframe refer with localhost:1633</h3>
-  <iframe id="localhost-iframe" src="http://localhost:1633/bzz/5f1eee1c57d03d1a423e2977875a707ed53cf72af45fdefba175f55336be1115"></iframe>
-  <h3>External image refer by BZZ protocol</h3>
-  <img id="bzz-image" width="300" src="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be/images/jinn.png">
-
-  <h3>Link to other page via web+bzz protocol</h3>
-  <a id="bzz-ext-ref" href="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be">Jinn page link 1</a>
+  <div id="test-cases">
+    <h2>BZZ Protocol samples</h2>
+    <div>
+      <h4>Local Iframe</h4>
+      <iframe id="localhost-inner-ref" src="jinn-page/index.html"></iframe>
+    </div>
+    <div>
+      <h4>BZZ Protocol Iframe</h4>
+      <iframe id="bzz-iframe" src="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be"></iframe>
+    </div>
+    <div>
+      <h4>Same External Iframe refer with localhost:1633</h4>
+      <iframe id="localhost-iframe" src="http://localhost:1633/bzz/5f1eee1c57d03d1a423e2977875a707ed53cf72af45fdefba175f55336be1115"></iframe>
+    </div>
+    <div>
+      <h4>External image refer by BZZ protocol</h4>
+      <img id="bzz-image" width="300" src="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be/images/jinn.png" />
+    </div>
+    <div>
+      <h4>Link to other page via web+bzz protocol</h4>
+      <a id="bzz-ext-ref" href="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be">Jinn page link 1</a>
+    </div>
+    <h2>Injected Swarm Script and Fake URL samples</h2>
+    <div>
+      <h4>Fetch Real Bee API URL</h4>
+      <button id="button-fetch-real-bee-api-url" onclick="fetchBeeApiUrl()">Fetch</button>
+      <label id="bee-api-url-placeholder">[Bee API URL Placeholder]</label>
+    </div>
+    <div>
+      <h4>Link to the other page via Fake URL</h4>
+      <a id="fake-url-ref" href="http://localhost:1633/fake-url/bzz/45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be">Jinn page link 2</a>
+    </div>
+    <div>
+      <h4>Fetch Jinn image via Fake URL with JavaScript</h4>
+      <button id="button-fetch-jinn-page" onclick="fetchJinnImage()">Fetch</button>
+      <div id="fake-url-fetch-jinn"></div>
+    </div>
+    <div>
+      <h4>Upload a file with BeeJS which is initialized by Fake URL</h4>
+      <button id="button-upload-fake-url-file" onclick="uploadFileWithBeeJs()">Upload</button>
+      <div id="fake-bzz-url-content-1"></div>
+    </div>
+  </div>
 </body>
 </html>
 

--- a/test/bzz-test-page/index.js
+++ b/test/bzz-test-page/index.js
@@ -1,0 +1,28 @@
+const web2Helper = window.swarm.web2Helper
+
+function fetchBeeApiUrl() {
+  web2Helper.beeApiUrl().then(url => (document.getElementById('bee-api-url-placeholder').innerHTML = url))
+}
+
+function fetchJinnImage() {
+  const bzzContentAddress = '45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be/images/jinn.png'
+  const jinnFakeUrl = web2Helper.fakeBzzAddress(bzzContentAddress)
+  const imageNode = document.createElement('img')
+  imageNode.src = jinnFakeUrl
+  imageNode.id = 'fetched-jinn-image'
+  imageNode.width = 300
+  document.getElementById('fake-url-fetch-jinn')?.appendChild(imageNode)
+}
+
+function uploadFileWithBeeJs() {
+  const beeUrl = web2Helper.fakeBeeApiAddress()
+  const bee = new window.BeeJs.Bee(beeUrl)
+  const files = [new File(['<h1>Uploaded File through Fake URL!</h1>'], 'index.html', { type: 'text/html' })]
+
+  bee.uploadFiles(files, { indexDocument: 'index.html' }).then(hash => {
+    const referenceNode = document.createElement('a')
+    referenceNode.href = web2Helper.fakeBzzAddress(hash)
+    referenceNode.innerHTML = hash
+    document.getElementById('fake-bzz-url-content-1')?.appendChild(referenceNode)
+  })
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import type puppeteer from 'puppeteer'
-import type { Web2Helper } from '../src/contentscript/swarm-library/web2-helper'
+import type { Web2HelperContent } from '../src/contentscript/web2-helper.content'
 export {} //indicate it is a module type declaration
 
 declare global {
@@ -10,7 +10,7 @@ declare global {
   }
   interface Window {
     swarm: {
-      web2Helper: Web2Helper
+      web2Helper: Web2HelperContent
     }
   }
 }


### PR DESCRIPTION
Init Fake URL structure and define how it could look like.

* Provide helpers to construct/get Fake URLs in injected scripts,
* amend `web+bzz` protocol resolving in content script according to the Fake URL structure,
* make changes in background request listeners,
* create Fake URL singleton in utils which used by contentscript/background script

Resolves #17 