### PR TITLE
feat: dapp session id registration

### DIFF
--- a/src/background/dapp-session.manager.ts
+++ b/src/background/dapp-session.manager.ts
@@ -1,0 +1,22 @@
+class DappSecurityContext {
+  public constructor(private tabId: number, private frameId: number) {}
+}
+
+export class DappSessionManager {
+  private securityContexts: { [sessionId: string]: DappSecurityContext }
+
+  public constructor() {
+    this.securityContexts = {}
+  }
+  public register(
+    sessionId: string,
+    sender: {
+      tabId: number
+      frameId: number
+    },
+  ): void {
+    const { tabId, frameId } = sender
+    this.securityContexts[sessionId] = new DappSecurityContext(tabId, frameId)
+    console.log(`dApp session "${sessionId}" has been initialized`)
+  }
+}

--- a/src/background/dapp-session.manager.ts
+++ b/src/background/dapp-session.manager.ts
@@ -1,5 +1,10 @@
 class DappSecurityContext {
-  public constructor(private tabId: number, private frameId: number) {}
+  public constructor(
+    private tabId: number,
+    private frameId: number,
+    private frameContentRoot: string,
+    private originContentRoot: string,
+  ) {}
 }
 
 export class DappSessionManager {
@@ -13,10 +18,12 @@ export class DappSessionManager {
     sender: {
       tabId: number
       frameId: number
+      frameContentRoot: string
+      originContentRoot: string
     },
   ): void {
-    const { tabId, frameId } = sender
-    this.securityContexts[sessionId] = new DappSecurityContext(tabId, frameId)
-    console.log(`dApp session "${sessionId}" has been initialized`)
+    const { tabId, frameId, frameContentRoot, originContentRoot } = sender
+    this.securityContexts[sessionId] = new DappSecurityContext(tabId, frameId, frameContentRoot, originContentRoot)
+    console.log(`dApp session "${sessionId}" has been initialized`, this.securityContexts[sessionId])
   }
 }

--- a/src/background/feeder/dapp-session.feeder.ts
+++ b/src/background/feeder/dapp-session.feeder.ts
@@ -27,9 +27,7 @@ export class DappSessionFeeder {
   }
 
   private senderTabId(sender: chrome.runtime.MessageSender) {
-    if (!sender.tab) throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "tab" property`, sender)
-
-    if (!sender.tab!.id) {
+    if (!sender.tab?.id) {
       throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "tab.id" property`, sender)
     }
 

--- a/src/background/feeder/dapp-session.feeder.ts
+++ b/src/background/feeder/dapp-session.feeder.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { ErrorWithConsoleLog } from '../../utils/error-with-console-log'
+import { IDappSessionMessage } from '../../utils/message/dapp-session/dapp-session.message'
+import { DirectMessageReq } from '../../utils/message/message-handler'
+import { DappSessionManager } from '../dapp-session.manager'
+
+export class DappSessionFeeder {
+  constructor(private manager: DappSessionManager) {
+    this.serveEvents()
+  }
+  serveEvents(): void {
+    console.log('Register DappSessionFeeder event listeners...')
+
+    chrome.runtime.onMessage.addListener((message, sender) => {
+      if (!this.isInternalMessage(sender)) return
+
+      if (this.isDappSessionMessage(message, 'registerDappSession')) {
+        this.manager.register(message.payload[0], {
+          tabId: this.senderTabId(sender),
+          frameId: this.senderFrameId(sender),
+        })
+      }
+    })
+  }
+
+  private senderTabId(sender: chrome.runtime.MessageSender) {
+    if (!sender.tab) throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "tab" property`, sender)
+
+    if (!sender.tab!.id) {
+      throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "tab.id" property`, sender)
+    }
+
+    return sender.tab.id
+  }
+
+  private senderFrameId(sender: chrome.runtime.MessageSender) {
+    if (!sender.frameId) {
+      throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "frameId" property`, sender)
+    }
+
+    return sender.frameId
+  }
+
+  private isDappSessionMessage<K extends keyof IDappSessionMessage>(
+    message: DirectMessageReq<IDappSessionMessage, any>,
+    method: K,
+  ): message is DirectMessageReq<IDappSessionMessage, K> {
+    if (message.key === method && message.trusted) return true
+
+    return false
+  }
+
+  private isInternalMessage(sender: chrome.runtime.MessageSender): boolean {
+    if (sender.id === chrome.runtime.id) return true
+
+    return false
+  }
+}

--- a/src/background/feeder/dapp-session.feeder.ts
+++ b/src/background/feeder/dapp-session.feeder.ts
@@ -82,8 +82,6 @@ export class DappSessionFeeder {
   }
 
   private isInternalMessage(sender: chrome.runtime.MessageSender): boolean {
-    if (sender.id === chrome.runtime.id) return true
-
-    return false
+    return sender.id === chrome.runtime.id
   }
 }

--- a/src/background/feeder/dapp-session.feeder.ts
+++ b/src/background/feeder/dapp-session.feeder.ts
@@ -34,9 +34,10 @@ export class DappSessionFeeder {
     return sender.tab.id
   }
 
+  /** If context is not in iframe it returns back -1 */
   private senderFrameId(sender: chrome.runtime.MessageSender) {
     if (!sender.frameId) {
-      throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "frameId" property`, sender)
+      return -1
     }
 
     return sender.frameId

--- a/src/background/feeder/dapp-session.feeder.ts
+++ b/src/background/feeder/dapp-session.feeder.ts
@@ -45,9 +45,7 @@ export class DappSessionFeeder {
 
   /** Gives back the original content reference of the sender */
   private senderContentOrigin(sender: chrome.runtime.MessageSender) {
-    if (!sender.tab) throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "tab" property`, sender)
-
-    if (!sender.tab!.url) {
+    if (!sender.tab?.url) {
       throw new ErrorWithConsoleLog(`DappSessionFeeder: sender does not have "tab.url" property`, sender)
     }
 

--- a/src/background/feeder/web2-helper.feeder.ts
+++ b/src/background/feeder/web2-helper.feeder.ts
@@ -9,9 +9,8 @@ export class Web2HelperFeeder {
     console.log('Register Web2HelperFeeder event listeners...')
 
     chrome.runtime.onMessage.addListener((message: InterceptorReqMessageFormat<string>, sender, sendResponse) => {
-      console.log('Web2HelperFeeder beeApiUrl got aimed message from content script', message)
-
       if (message.key === 'beeApiUrl') {
+        console.log('Web2HelperFeeder:beeApiUrl got aimed message from content script', message)
         const response: ResponseMessageFormat = {
           key: message.key,
           sender: 'background',

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,4 +1,6 @@
 import { StoreObserver } from '../utils/storage'
+import { DappSessionManager } from './dapp-session.manager'
+import { DappSessionFeeder } from './feeder/dapp-session.feeder'
 import { Web2HelperFeeder } from './feeder/web2-helper.feeder'
 import { BeeApiListener } from './listener/bee-api.listener'
 import { DebugListener } from './listener/debug.listener'
@@ -7,6 +9,8 @@ import { setupLiveReload } from './live-reload/live-reload'
 console.log('Swarm Backend script started...')
 const storeObserver = new StoreObserver()
 const beeApiListener = new BeeApiListener(storeObserver)
+const dappSessionManager = new DappSessionManager()
+new DappSessionFeeder(dappSessionManager)
 new DebugListener()
 new Web2HelperFeeder(beeApiListener)
 setupLiveReload()

--- a/src/contentscript/document-start/dapp-session.register.ts
+++ b/src/contentscript/document-start/dapp-session.register.ts
@@ -1,0 +1,12 @@
+import { IDappSessionMessage } from '../../utils/message/dapp-session/dapp-session.message'
+import { DirectMessageReq } from '../../utils/message/message-handler'
+
+export function dappSessionRegister(sessionId: string): void {
+  const messageToBackground: DirectMessageReq<IDappSessionMessage, 'registerDappSession'> = {
+    key: 'registerDappSession',
+    payload: [sessionId],
+    trusted: true,
+  }
+
+  chrome.runtime.sendMessage(messageToBackground)
+}

--- a/src/contentscript/document-start/index.ts
+++ b/src/contentscript/document-start/index.ts
@@ -1,36 +1,20 @@
-//Only does the injection of Swarm library on document start
-// import { assignSwarmLibraryToWindow } from '../swarm-library'
-
-import SwarmLibrary from 'raw-loader!../../../dist/swarm-library.js'
 import { MessengerInterceptor } from './messenger.interceptor'
-
-/**
- * Injects a script tag into the current document
- *
- * @param content - Code to be executed in the current document
- */
-function injectScript(content: string) {
-  try {
-    const container = document.head || document.documentElement
-    const scriptTag = document.createElement('script')
-    scriptTag.setAttribute('async', 'false')
-    scriptTag.id = 'swarm-injected'
-    scriptTag.textContent = content
-    container.insertBefore(scriptTag, container.children[0])
-    container.removeChild(scriptTag)
-    console.log('Swarm-Extension: swarm-library is available via "window.swarm"')
-  } catch (error) {
-    console.error('Swarm-Extension: Provider injection failed.', error)
-  }
-}
-
-injectScript(SwarmLibrary)
+import { injectSessionId } from './inject/session-id'
+import { injectSwarmLibrary } from './inject/swarm-library'
+import { nanoid } from 'nanoid'
+import { dappSessionRegister } from './dapp-session.register'
 
 // custom protocol handler is highly unconvenient to set up on client side and cannot be enabled automaticly in puppeteer
 // it does not have effect on image loading
 // it cannot be called via XMLHtmlRequest, because it is not in the supported protocol schemes
 // and various fixed protocol scheme validations block to utilize this redirect
 // window.navigator.registerProtocolHandler('web+bzz', `${dappRequestUrl}?bzz-address=%s`, 'Swarm dApp')
+
+// Generate dapp session id
+const sessionId = nanoid()
+dappSessionRegister(sessionId)
+injectSessionId(sessionId)
+injectSwarmLibrary()
 
 //listen to events which come from inpage side
 new MessengerInterceptor()

--- a/src/contentscript/document-start/inject/session-id.ts
+++ b/src/contentscript/document-start/inject/session-id.ts
@@ -1,0 +1,5 @@
+import { injectScript } from '../utils'
+
+export function injectSessionId(sessionId: string): void {
+  injectScript(`window.swarmSessionId = '${sessionId}'`, 'swarmSessionId')
+}

--- a/src/contentscript/document-start/inject/swarm-library.ts
+++ b/src/contentscript/document-start/inject/swarm-library.ts
@@ -1,0 +1,7 @@
+import SwarmLibrary from 'raw-loader!../../../../dist/swarm-library.js'
+import { injectScript } from '../utils'
+
+/** Only does the injection of Swarm library on document start */
+export function injectSwarmLibrary(): void {
+  injectScript(SwarmLibrary, 'swarm')
+}

--- a/src/contentscript/document-start/messenger.interceptor.ts
+++ b/src/contentscript/document-start/messenger.interceptor.ts
@@ -7,10 +7,11 @@ import {
 } from '../../utils/message/message-handler'
 
 export class MessengerInterceptor {
-  private readonly inpageOrigin = window.location.origin
+  private readonly inpageOrigin = window.origin !== 'null' ? window.origin : '*'
 
   constructor() {
     this.serveEvents()
+    console.log('message interceptor has been initialized.', this.inpageOrigin)
   }
   serveEvents(): void {
     console.log('Register Web2HelperInterceptor event listeners...')

--- a/src/contentscript/document-start/utils.ts
+++ b/src/contentscript/document-start/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Injects a script tag into the current document
+ *
+ * @param content - Code to be executed in the current document
+ */
+export function injectScript(content: string, windowObjectName: string): void {
+  try {
+    const container = document.head || document.documentElement
+    const scriptTag = document.createElement('script')
+    scriptTag.setAttribute('async', 'false')
+    scriptTag.textContent = content
+    container.insertBefore(scriptTag, container.children[0])
+    container.removeChild(scriptTag)
+    console.log(`Swarm-Extension: injected object is available via "window.${windowObjectName}"`)
+  } catch (error) {
+    console.error('Swarm-Extension: Provider injection failed.', error)
+  }
+}

--- a/src/contentscript/swarm-library/messenger.inpage.ts
+++ b/src/contentscript/swarm-library/messenger.inpage.ts
@@ -1,7 +1,7 @@
 import { InterceptorResMessageFormat } from '../../utils/message/message-handler'
 
 export class MessengerInpage {
-  protected readonly contentPageOrigin = window.location.origin
+  protected readonly contentPageOrigin = window.origin
 
   protected validMessage(response: MessageEvent<InterceptorResMessageFormat<unknown>>, eventId: string): boolean {
     if (

--- a/src/contentscript/web2-helper.content.ts
+++ b/src/contentscript/web2-helper.content.ts
@@ -34,7 +34,8 @@ export class Web2HelperContent extends MessengerInpage implements IWeb2HelperMes
       }
 
       window.addEventListener('message', handler)
-      window.postMessage(message, window.location.origin)
+      const origin = window.origin !== 'null' ? window.origin : '*'
+      window.postMessage(message, origin)
     })
   }
 

--- a/src/utils/error-with-console-log.ts
+++ b/src/utils/error-with-console-log.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export class ErrorWithConsoleLog extends Error {
+  constructor(message: string, ...consoleMessages: any[]) {
+    console.error(message, ...consoleMessages)
+    super(message)
+  }
+}

--- a/src/utils/message/dapp-session/dapp-session.message.ts
+++ b/src/utils/message/dapp-session/dapp-session.message.ts
@@ -1,0 +1,5 @@
+// Define your message types like that:
+// Key: Message name; Parameter: payload data from sender side, Return Value: Feeder functions emit
+export interface IDappSessionMessage {
+  registerDappSession: (sessionId: string) => void
+}

--- a/src/utils/message/message-handler.ts
+++ b/src/utils/message/message-handler.ts
@@ -61,9 +61,3 @@ export type ResponseMessageFormat<T = string> = BaseMessageFormat & {
 export type ResponseWithMessage<T = string> = {
   [Property in keyof ResponseMessageFormat<T> as Exclude<Property, 'error'>]-?: ResponseMessageFormat<T>[Property]
 }
-
-export function assertMessage<T extends BaseMessageFormat, K extends keyof T>(message: T, method: K): message is T {
-  if (message.key === method) return true
-
-  return false
-}

--- a/src/utils/message/message-handler.ts
+++ b/src/utils/message/message-handler.ts
@@ -6,6 +6,22 @@ type BaseMessageFormat = {
   key: string
 }
 
+type BaseDirectMessage = BaseMessageFormat & {
+  trusted: true
+}
+
+/** Direct message from Content script to Background script */
+export type DirectMessageReq<T, K extends keyof T> = BaseDirectMessage & {
+  key: K
+  payload: T[K] extends (...args: any[]) => any ? Parameters<T[K]> : undefined
+}
+
+/** Response for Content script direct message from Background script */
+export type DirectMessageRes<T, K extends keyof T> = BaseDirectMessage & {
+  key: K
+  payload: T[K] extends (...args: any[]) => any ? ReturnType<T[K]> : never
+}
+
 /** Used message type where window.postMessage call happens */
 export type BroadcastMessageFormat = BaseMessageFormat & {
   eventId: string
@@ -44,4 +60,10 @@ export type ResponseMessageFormat<T = string> = BaseMessageFormat & {
 /** Background script -> Content script with answer */
 export type ResponseWithMessage<T = string> = {
   [Property in keyof ResponseMessageFormat<T> as Exclude<Property, 'error'>]-?: ResponseMessageFormat<T>[Property]
+}
+
+export function assertMessage<T extends BaseMessageFormat, K extends keyof T>(message: T, method: K): message is T {
+  if (message.key === method) return true
+
+  return false
 }

--- a/src/utils/message/web2-helper/web2-helper.message.ts
+++ b/src/utils/message/web2-helper/web2-helper.message.ts
@@ -1,5 +1,5 @@
 // Define your message types like that:
-// Key: Message name; Value: Feeder functions emit
+// Key: Message name; Parameter: payload data from sender side, Return Value: Feeder functions emit
 export interface IWeb2HelperMessage {
   beeApiUrl: () => Promise<string>
 }

--- a/test/bzz-test-page/index.html
+++ b/test/bzz-test-page/index.html
@@ -17,15 +17,15 @@
     <h2>BZZ Protocol samples</h2>
     <div>
       <h4>Local Iframe</h4>
-      <iframe id="localhost-inner-ref" src="jinn-page/index.html"></iframe>
+      <iframe id="localhost-inner-ref" referrerpolicy="unsafe-url" src="jinn-page/index.html"></iframe>
     </div>
     <div>
       <h4>BZZ Protocol Iframe</h4>
-      <iframe id="bzz-iframe" src="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be"></iframe>
+      <iframe id="bzz-iframe" referrerpolicy="unsafe-url" sandbox="allow-scripts" src="web+bzz://45761400d69cd972bf0bc1aaaacd809c9d2687eed3ece09836320f887143d9be"></iframe>
     </div>
     <div>
       <h4>Same External Iframe refer with localhost:1633</h4>
-      <iframe id="localhost-iframe" src="http://localhost:1633/bzz/5f1eee1c57d03d1a423e2977875a707ed53cf72af45fdefba175f55336be1115"></iframe>
+      <iframe id="localhost-iframe" referrerpolicy="unsafe-url" sandbox="allow-scripts" src="http://localhost:1633/bzz/5f1eee1c57d03d1a423e2977875a707ed53cf72af45fdefba175f55336be1115"></iframe>
     </div>
     <div>
       <h4>External image refer by BZZ protocol</h4>


### PR DESCRIPTION
This PR only sorts out the session ID registration for dApp security context.
In the subsequent PRs every dApp _frames_ which aim Bee endpoints or manage its state must append this sessionId in the `dapp-session-id` header to these requests.

Resolves #24