### PR TITLE
feat: csp header

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Unfortunately, [Chrome does not have exposed function to register custom protoco
 
 Chrome lets you to register custom protocol in the context of the webpage, but only with prefix `web+`.
 Nevertheless you can refer to any `bzz` resource in html if you add attribute `is=swarm-X` to your html element like `<img is="swarm-img" src="bzz://{content-address}" />`.
+
 Current supported elements:
 * `a` -> `<a is="swarm-a" (...)`
 * `img` -> `<img is="swarm-image" (...)`
@@ -57,7 +58,17 @@ Current supported elements:
 
 In search bar the `bzz://{content-address}` will be redirected to `http(s)://{localgateway}/bzz/{content-address}`, but now it only reacts like this if the default search engine of the browser is set to Google. It also works the same on simple google search.
 
+## dApp origin instead of host-based origin
+
+All Swarm content that the extension renders will be put into _sandbox_ mode even in root level by _Content Security Policy_ headers.
+It means dApps will act like a different, distinct webpage from the Bee host that serves those.
+Therefore no traditional _cookies_ or _localStorage_ is available for dApps, but equivalent services of those are.
+
+In order to substitue these traditional stateful behaviours of the applications with something else, the Swarm Extension introduces
+the `dApp Security Context` as a new abstraction of origins.
+
 ## Cross-Domain Local Storage
+
 In Web3, several different and distinct webpages can be rendered under one particular P2P client host.
 It is a problem, because if the user changes its P2P client host then they have to rebuild again the dApp state from the start.
 
@@ -100,4 +111,3 @@ In its [index page](test/bzz-test-page/index.html), you see how you can refer to
 
 - [nugaon](https://github.com/nugaon)
 - [Cafe137](https://github.com/Cafe137)
-

--- a/src/background/dapp-session.manager.ts
+++ b/src/background/dapp-session.manager.ts
@@ -15,9 +15,7 @@ class DappSecurityContext {
     private originContentRoot: string,
   ) {
     this.storage = chrome.storage.local
-    this.storePrefix = this.frameContentRoot
-      ? `${this.originContentRoot}:${this.frameContentRoot}`
-      : this.originContentRoot
+    this.storePrefix = this.frameContentRoot || this.originContentRoot
   }
 
   public isValidTabId(tabId: number): boolean {

--- a/src/contentscript/document-start/index.ts
+++ b/src/contentscript/document-start/index.ts
@@ -1,9 +1,10 @@
-import { MessengerInterceptor } from './messenger.interceptor'
-import { injectSessionId } from './inject/session-id'
-import { injectSwarmLibrary } from './inject/swarm-library'
 import { nanoid } from 'nanoid'
 import { dappSessionRegister } from './dapp-session.register'
+import { injectSandboxPolyfill } from './inject/sandbox-polyfill'
+import { injectSessionId } from './inject/session-id'
 import { injectSwarmHtml } from './inject/swarm-html'
+import { injectSwarmLibrary } from './inject/swarm-library'
+import { MessengerInterceptor } from './messenger.interceptor'
 
 // custom protocol handler is highly unconvenient to set up on client side and cannot be enabled automaticly in puppeteer
 // it does not have effect on image loading
@@ -13,6 +14,7 @@ import { injectSwarmHtml } from './inject/swarm-html'
 
 // Generate dapp session id
 const sessionId = nanoid()
+injectSandboxPolyfill()
 dappSessionRegister(sessionId)
 injectSessionId(sessionId)
 injectSwarmHtml()

--- a/src/contentscript/document-start/index.ts
+++ b/src/contentscript/document-start/index.ts
@@ -12,13 +12,20 @@ import { MessengerInterceptor } from './messenger.interceptor'
 // and various fixed protocol scheme validations block to utilize this redirect
 // window.navigator.registerProtocolHandler('web+bzz', `${dappRequestUrl}?bzz-address=%s`, 'Swarm dApp')
 
-// Generate dapp session id
-const sessionId = nanoid()
-injectSandboxPolyfill()
-dappSessionRegister(sessionId)
-injectSessionId(sessionId)
-injectSwarmHtml()
-injectSwarmLibrary()
+function init(): void {
+  const sessionId = nanoid()
+  dappSessionRegister(sessionId)
+  injectSessionId(sessionId)
+  injectSwarmHtml()
+  injectSwarmLibrary()
 
-//listen to events which come from inpage side
-new MessengerInterceptor()
+  //listen to events which come from inpage side
+  new MessengerInterceptor()
+
+  // all bzz root content has to be in sandbox because of the CSP
+  if (window.origin !== 'null') return
+  // Generate dapp session id
+  injectSandboxPolyfill()
+}
+
+init()

--- a/src/contentscript/document-start/inject/sandbox-polyfill.ts
+++ b/src/contentscript/document-start/inject/sandbox-polyfill.ts
@@ -1,0 +1,12 @@
+import { injectScript } from '../utils'
+
+/**
+ * dApps will be opened in sandbox mode,
+ * and as a result some common libraries won't work without polyfilling
+ */
+export function injectSandboxPolyfill(): void {
+  injectScript(
+    "Object.defineProperty(document, 'cookie', { get: function(){return ''}, set: function(){return true}, });",
+    'sandboxPolyfill',
+  )
+}

--- a/test/bzz-test-page/index.html
+++ b/test/bzz-test-page/index.html
@@ -55,7 +55,7 @@
     <h2>Local Storage handling</h2>
     <div>
       <h4>Local Storage handling in other dApp within iframe</h4>
-      <iframe id="localstorage-iframe" is="swarm-frame" src="bzz://e2252fc14fb7f7cea2f5f67c90f1522f7d79a63c19fe2980fa20980d3b70359a"></iframe>
+      <iframe id="localstorage-iframe" is="swarm-frame" src="bzz://c946b39c82d85e2eef49321eac33d46bc00912b182f35476eadf1285800d7111"></iframe>
     </div>
   </div>
 </body>

--- a/test/bzz-test-page/local-storage/index.html
+++ b/test/bzz-test-page/local-storage/index.html
@@ -5,22 +5,10 @@
   <meta charset="utf-8">
   <title>Local Storage handling</title>
   <script>
-    function saveWithTraditionalLocalStorage() {
-    const keyName = document.getElementById('save-localstorage-key-name').value
-    const keyValue = document.getElementById('save-localstorage-key-value').value
-    window.localStorage.setItem(keyName, keyValue)
-  }
-
   async function saveWithSwarmLocalStorage() {
     const keyName = document.getElementById('save-localstorage-key-name').value
     const keyValue = document.getElementById('save-localstorage-key-value').value
     await window.swarm.localStorage.setItem(keyName, keyValue)
-  }
-
-  function loadWithTraditionalLocalStorage() {
-    const keyName = document.getElementById('load-localstorage-key-name').value
-    const keyValue = window.localStorage.getItem(keyName)
-    document.getElementById('load-localstorage-key-value').innerHTML = keyValue
   }
 
   async function loadWithSwarmLocalStorage() {
@@ -36,25 +24,23 @@
     Local Storage handling
   </h2>
   <div>
-    <h4>Save data with traditional and Swarm localStorage</h4>
+    <h4>Save data with Swarm localStorage</h4>
     <div id="form-save-localstorage">
       <label for="save-localstorage-key-name">Key:</label>
       <input type="text" id="save-localstorage-key-name" name="save-localstorage-key-name"/><br><br>
       <label for="save-localstorage-key-value">Value:</label>
       <input type="text" id="save-localstorage-key-value" name="save-localstorage-key-value">
     </div>
-    <button id="button-save-traditional-localstorage" class="block-element" onclick="saveWithTraditionalLocalStorage()">Save with window.localStorage</button>
     <button id="button-save-swarm-localstorage" class="block-element" onclick="saveWithSwarmLocalStorage()">Save with swarm.localStorage</button>
   </div>
   <div>
-    <h4>Load data with traditional and Swarm localStorage</h4>
+    <h4>Load data with Swarm localStorage</h4>
     <div id="form-load-localstorage">
       <label for="load-localstorage-key-name">Key:</label>
       <input type="text" id="load-localstorage-key-name" name="load-localstorage-key-name"/><br><br>
       <label for="load-localstorage-key-value">Value:</label>
       <span id="load-localstorage-key-value"></span>
     </div>
-    <button id="button-load-traditional-localstorage" class="block-element" onclick="loadWithTraditionalLocalStorage()">Load with window.localStorage</button>
     <button id="button-load-swarm-localstorage" class="block-element" onclick="loadWithSwarmLocalStorage()">Load with swarm.localStorage</button>
   </div>
 </body>


### PR DESCRIPTION
This PR research the usage of [Content Security Policy headers](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) for web3.

The problem when a dApps is loaded, it shares the [same origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) with other dApps that also load from the same host (Bee client).

As the CSP's docs states: 
> If the site doesn't offer the CSP header, browsers likewise use the standard same-origin policy.

Before any same-origin policy would take effect, with CSP header it is possible to put the content into `sandbox` as at `iframe` tags. One of its consequences, the dApp will lose the origin of the P2P client from which it was served and it cannot reach other dApps from the same origin.

The extension can alter any requests/responses, therefore there is no need to configure any server-side to test the behaviours of the CSP headers.

one other consequence of this approach is the cross-domain localstorage of dapps can retrieve their origin's saved data in `iframe`s instead of the its corresponding subset of the opened root apps.

It is required from the reviewer(s) to check the concept manually with `npm run test:demo` and testing any possible security concerns regarding to the feature.