### PR TITLE
refactor: fakeurl base address

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ the dApps will call it in the same way.
 
 ### Callable Endpoints
 
-For any action the Fake URL host is `http://localhost:1633`.
+For any action the Fake URL host is `http://swarm.fakeurl.localhost`.
 As it is written earlier, it is not the address of the Bee client,
 it is just a reserved host address that the extension took and built its Fake URL paths on it.
 If the user changes their Bee API address, these callings still remain the same from dApp side.
 
-- `http://localhost:1633/fake-url/bzz/*` - `BZZ protocol` redirects to this fake URL, thereby in `*` can be not only content reference with its path, but any BZZ protocol compatible reference. It will be redirected to `bzz` endpoint of the Bee client.
-- `http://localhost:1633/fake-url/bee-api/*` - it will be forwarded to the Bee API. `*` has to be valid Bee API path
+- `http://swarm.fakeurl.localhost/bzz/*` - `BZZ protocol` redirects to this fake URL, thereby in `*` can be not only content reference with its path, but any BZZ protocol compatible reference. It will be redirected to `bzz` endpoint of the Bee client.
+- `http://swarm.fakeurl.localhost/bee-api/*` - it will be forwarded to the Bee API. `*` has to be valid Bee API path
 
 ## Custom Protocol
 

--- a/src/utils/fake-url.ts
+++ b/src/utils/fake-url.ts
@@ -24,7 +24,7 @@ class FakeUrl {
     // 'fake-url' part does not exist and should not in the future
     // does not need to change even if the client set other URL for bzz protocol
     // does not change during the workflow
-    this.baseUrl = 'http://localhost:1633/fake-url'
+    this.baseUrl = 'http://swarm.fakeurl.localhost'
     this.bzzProtocol = `${this.baseUrl}/bzz`
     this.beeApiAddress = `${this.baseUrl}/bee-api`
     this.openDapp = `${this.baseUrl}/open-dapp`


### PR DESCRIPTION
fakeurl base address changed from `http://localhost:1633/fakeurl` to `http://swarm.fakeurl.localhost`.

Closes #17 