### PR TITLE
build(fix): build production mode by default

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -463,10 +463,15 @@ const popupPage = (env?: Partial<WebpackEnvParams>): Configuration => {
 }
 
 export default (env?: Partial<WebpackEnvParams>): Configuration[] => {
+  let baseConfig: Configuration[]
+
+  // if environment node is undefined then it always build in production mode
+  if (!env?.mode) {
+    env = { ...env, mode: 'production' }
+  }
+
   // eslint-disable-next-line no-console
   console.log('env', env)
-
-  let baseConfig: Configuration[]
 
   if (env?.buildDeps) {
     if (env?.mode === 'development') liveReloadServer = new Server({ port: DEPS_RELOAD_PORT })


### PR DESCRIPTION
There was a problem if the hot-reload server wasn't running the extension didn't functionate.

It was because on `compile` npm run script the `--env mode=production` flag wasn't passed.
because we have only one run script that uses development mode where the mode flag is defined, I made the build `production` mode by default if the flag is not present. 

Resolves #52