### PR TITLE
refactor: session id in url

### DIFF
--- a/src/contentscript/document-start/messenger.interceptor.ts
+++ b/src/contentscript/document-start/messenger.interceptor.ts
@@ -8,7 +8,11 @@ import {
 } from '../../utils/message/message-handler'
 
 export class MessengerInterceptor {
-  private readonly inpageOrigin = window.origin !== 'null' ? window.origin : '*'
+  /**
+   * TODO: target by app origin
+   * origin is null because of the sandbox
+   */
+  private readonly inpageOrigin = '*'
 
   constructor() {
     this.serveEvents()

--- a/src/contentscript/swarm-library/bzz-link.ts
+++ b/src/contentscript/swarm-library/bzz-link.ts
@@ -7,9 +7,11 @@ export function bzzProtocolToFakeUrl(url: string, newPage = false): string | nul
   if (!url.startsWith('bzz://')) return null
 
   const bzzReference = url.substr('bzz://'.length)
-  const fakeUrlRef = newPage ? `${fakeUrl.openDapp}/${bzzReference}` : `${fakeUrl.bzzProtocol}/${bzzReference}`
+  const fakeUrlRef = newPage
+    ? `${fakeUrl.openDapp}/${bzzReference}` // does not need sessionId because it force redirects
+    : appendSwarmSessionIdToUrl(`${fakeUrl.bzzProtocol}/${bzzReference}`)
 
-  return appendSwarmSessionIdToUrl(fakeUrlRef)
+  return fakeUrlRef
 }
 
 /** gives back the fake URL of the bzz.link or null if the first parameter is not a valid bzz.link reference */

--- a/src/contentscript/swarm-library/local-storage.ts
+++ b/src/contentscript/swarm-library/local-storage.ts
@@ -28,7 +28,11 @@ export class LocalStorage extends MessengerInpage implements ILocalStorageMessag
       }
 
       window.addEventListener('message', handler)
-      const origin = window.origin !== 'null' ? window.origin : '*'
+      /**
+       * TODO: target by app origin
+       * origin is null because of the sandbox
+       */
+      const origin = '*'
       window.postMessage(message, origin)
     })
   }
@@ -63,7 +67,11 @@ export class LocalStorage extends MessengerInpage implements ILocalStorageMessag
       }
 
       window.addEventListener('message', handler)
-      const origin = window.origin !== 'null' ? window.origin : '*'
+      /**
+       * TODO: target by app origin
+       * origin is null because of the sandbox
+       */
+      const origin = '*'
       window.postMessage(message, origin)
     })
   }

--- a/src/contentscript/swarm-library/web2-helper.content.ts
+++ b/src/contentscript/swarm-library/web2-helper.content.ts
@@ -35,7 +35,11 @@ export class Web2HelperContent extends MessengerInpage implements IWeb2HelperMes
       }
 
       window.addEventListener('message', handler)
-      const origin = window.origin !== 'null' ? window.origin : '*'
+      /**
+       * TODO: target by app origin
+       * origin is null because of the sandbox
+       */
+      const origin = '*'
       window.postMessage(message, origin)
     })
   }

--- a/src/utils/swarm-session-id.ts
+++ b/src/utils/swarm-session-id.ts
@@ -13,7 +13,7 @@ export const SWARM_SESSION_ID_KEY = 'swarm-session-id'
  * @throws if the sessionId is not found in the URL
  */
 export function unpackSwarmSessionIdFromUrl(bzzUrl: string): { sessionId: string; originalUrl: string } {
-  const searchString = `/__${SWARM_SESSION_ID_KEY}~`
+  const searchString = `__${SWARM_SESSION_ID_KEY}~`
   const sessionIdParamIndex = bzzUrl.indexOf(searchString)
 
   if (sessionIdParamIndex === -1) throw new Error(`There is no ${SWARM_SESSION_ID_KEY} element in url ${bzzUrl}`)
@@ -34,5 +34,5 @@ export function unpackSwarmSessionIdFromUrl(bzzUrl: string): { sessionId: string
 }
 
 export function appendSwarmSessionIdToUrl(fakeUrlRef: string): string {
-  return `${fakeUrlRef}/__${SWARM_SESSION_ID_KEY}~${window.swarm.sessionId}__`
+  return `${fakeUrlRef}__${SWARM_SESSION_ID_KEY}~${window.swarm.sessionId}__`
 }

--- a/src/utils/swarm-session-id.ts
+++ b/src/utils/swarm-session-id.ts
@@ -10,30 +10,29 @@ export const SWARM_SESSION_ID_KEY = 'swarm-session-id'
  *
  * @param bzzUrl BZZ URL with arbitrary query parameters, e.g. http://.../1231abcd.../valami.html?swarm-session-id=vmi&smth=5
  * @returns url without the SwarmSessionID
+ * @throws if the sessionId is not found in the URL
  */
-export function removeSwarmSessionIdFromUrl(bzzUrl: string): string {
-  const queryIndex = bzzUrl.indexOf('?')
+export function unpackSwarmSessionIdFromUrl(bzzUrl: string): { sessionId: string; originalUrl: string } {
+  const searchString = `/__${SWARM_SESSION_ID_KEY}~`
+  const sessionIdParamIndex = bzzUrl.indexOf(searchString)
 
-  if (queryIndex === -1) return bzzUrl
+  if (sessionIdParamIndex === -1) throw new Error(`There is no ${SWARM_SESSION_ID_KEY} element in url ${bzzUrl}`)
 
-  const invalidQueryEnds = bzzUrl.indexOf('/', queryIndex + 1)
+  const sessionIdStartIndex = sessionIdParamIndex + searchString.length
+  const sessionIdEndIndex = bzzUrl.indexOf('__', sessionIdStartIndex)
 
-  if (invalidQueryEnds !== -1) {
-    // remove the whole string chunk starting from the invalid '?' query sign up to the first slash
-    return bzzUrl.slice(0, queryIndex) + bzzUrl.slice(invalidQueryEnds)
+  const sessionId = bzzUrl.substring(sessionIdStartIndex, sessionIdEndIndex)
+  console.log('sessionId', sessionId)
+
+  const originalUrl = bzzUrl.split(searchString + sessionId + '__').join('')
+  console.log('originalUrl', originalUrl)
+
+  return {
+    sessionId,
+    originalUrl,
   }
-
-  // if the process reaches this point, the given url can be handled as with valid query parameter
-  const constructedUrl = new URL(bzzUrl)
-  constructedUrl.searchParams.delete(SWARM_SESSION_ID_KEY)
-
-  return constructedUrl.toString()
 }
 
 export function appendSwarmSessionIdToUrl(fakeUrlRef: string): string {
-  const fakeUrl = new URL(fakeUrlRef)
-  const fakeUrlRefParams = new URLSearchParams(fakeUrl.search.slice(1))
-  fakeUrlRefParams.append(SWARM_SESSION_ID_KEY, window.swarm.sessionId)
-
-  return `${fakeUrlRef}?${fakeUrlRefParams.toString()}`
+  return `${fakeUrlRef}/__${SWARM_SESSION_ID_KEY}~${window.swarm.sessionId}__`
 }

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -1,0 +1,24 @@
+import { nanoid } from 'nanoid'
+import { fakeUrl as FakeUrl } from '../src/utils/fake-url'
+import { SWARM_SESSION_ID_KEY, unpackSwarmSessionIdFromUrl } from '../src/utils/swarm-session-id'
+
+describe('Unit', () => {
+  const testBzzHash = '82de75aa2e4e27eefc3c00f5cdc7a2cb787402906a73609803de0ee25602b4f5'
+
+  test('Unpack Swarm session ID from URL', () => {
+    const fakeUrl = `${FakeUrl.beeApiAddress}/bzz/${testBzzHash}`
+    const sessionId = nanoid()
+    const fakeUrlWithSessionId = `${fakeUrl}__${SWARM_SESSION_ID_KEY}~${sessionId}__`
+    const { originalUrl: fakeUrlAgain, sessionId: sessionIdAgain } = unpackSwarmSessionIdFromUrl(fakeUrlWithSessionId)
+
+    expect(fakeUrlAgain).toBe(fakeUrl)
+    expect(sessionIdAgain).toBe(sessionId)
+  })
+
+  test('Throw error at Unpacking Swarm session ID from wrong URL', () => {
+    const fakeUrl = `${FakeUrl.beeApiAddress}/bzz/${testBzzHash}`
+    const sessionId = nanoid()
+    const fakeUrlWithSessionId = `${fakeUrl}__not-swarm-session-id~${sessionId}__`
+    expect(() => unpackSwarmSessionIdFromUrl(fakeUrlWithSessionId)).toThrowError()
+  })
+})


### PR DESCRIPTION
Some Bee endpoints have query parameters (like the feed ep) and then `bee-js` trims the base URL's query params out. To fix this issue, the `sessionId` is no longer encapsulated as a query parameter, instead it is in form of `/__swarm-session-id~${id}__` in the FakeURL.

Addtional fix: React applications couldn't emit state change events because the CSP header `sandbox` mode didn't allow that. It is fixed now by adding `allow-forms`.
