### PR TITLE
feat: web2 origin checkbox

### DIFF
--- a/src/contentscript/document-start/index.ts
+++ b/src/contentscript/document-start/index.ts
@@ -22,7 +22,7 @@ function init(): void {
   //listen to events which come from inpage side
   new MessengerInterceptor()
 
-  // all bzz root content has to be in sandbox because of the CSP
+  // for all bzz content which is in sandbox because of the CSP
   if (window.origin !== 'null') return
   // Generate dapp session id
   injectSandboxPolyfill()

--- a/src/popup-page/context/global.tsx
+++ b/src/popup-page/context/global.tsx
@@ -18,6 +18,7 @@ interface State {
   beeDebugApiUrl: string
   postageBatchId: string | null
   globalPostageBatchEnabled: boolean
+  web2OriginEnabled: boolean
 }
 
 interface ActionBeeUrlSave {
@@ -39,12 +40,22 @@ interface ActionPostageBatchSave {
   newValue: string | null
 }
 
+interface ActionWeb2OriginEnableSave {
+  type: 'WEB2_ORIGIN_ENABLED_SAVE'
+  newValue: boolean
+}
+
 /**
  * The actions types are either ending with `_SAVE` or `_CHANGE`.
  *
  * The former saves the value into the localStorage, the latter only changes the globalState in the React app.
  */
-type Action = ActionPostageBatchSave | ActionBeeUrlSave | ActionGlobalPostageBatchEnabledSave | ActionBeeDebugUrlSave
+type Action =
+  | ActionPostageBatchSave
+  | ActionBeeUrlSave
+  | ActionGlobalPostageBatchEnabledSave
+  | ActionBeeDebugUrlSave
+  | ActionWeb2OriginEnableSave
 
 interface ContextValue {
   state: State
@@ -55,6 +66,9 @@ async function localStoreDispatch(action: Action): Promise<void> {
   switch (action.type) {
     case 'BEE_API_URL_SAVE':
       await setItem('beeApiUrl', action.newValue)
+      break
+    case 'WEB2_ORIGIN_ENABLED_SAVE':
+      await setItem('web2OriginEnabled', action.newValue)
       break
     case 'GLOBAL_POSTAGE_BATCH_SAVE':
       await setItem('globalPostageBatch', action.newValue)
@@ -75,6 +89,7 @@ const initialState: State = {
   beeDebugApiUrl: 'http://localhost:1635',
   postageBatchId: null,
   globalPostageBatchEnabled: false,
+  web2OriginEnabled: false,
 }
 
 const GlobalContext = createContext<ContextValue>({
@@ -92,6 +107,8 @@ const GlobalStateProvider = ({ children }: { children: React.ReactElement }): Re
         return { ...state, beeApiUrl: action.newValue }
       case 'BEE_DEBUG_API_URL_SAVE':
         return { ...state, beeDebugApiUrl: action.newValue }
+      case 'WEB2_ORIGIN_ENABLED_SAVE':
+        return { ...state, web2OriginEnabled: action.newValue }
       case 'GLOBAL_POSTAGE_BATCH_SAVE':
         return { ...state, postageBatchId: action.newValue }
       case 'GLOBAL_POSTAGE_BATCH_ENABLED_SAVE':
@@ -115,6 +132,11 @@ const GlobalStateProvider = ({ children }: { children: React.ReactElement }): Re
         uiStateDispatch({ type: 'BEE_DEBUG_API_URL_SAVE', newValue })
       }
     }
+    const web2OriginEnableListener = (newValue: boolean, oldValue: boolean) => {
+      if (newValue !== oldValue && newValue !== state.web2OriginEnabled) {
+        uiStateDispatch({ type: 'WEB2_ORIGIN_ENABLED_SAVE', newValue })
+      }
+    }
     // localstore changes effect back the handled state
     const globalPostageBatchListener = (newValue: string, oldValue: string) => {
       if (newValue !== oldValue && newValue !== state.postageBatchId) {
@@ -131,12 +153,14 @@ const GlobalStateProvider = ({ children }: { children: React.ReactElement }): Re
     storeObserver.addListener('beeDebugApiUrl', beeDebugApiUrlListener)
     storeObserver.addListener('globalPostageBatch', globalPostageBatchListener)
     storeObserver.addListener('globalPostageStampEnabled', globalPostageBatchEnabledListener)
+    storeObserver.addListener('web2OriginEnabled', web2OriginEnableListener)
 
     return () => {
       storeObserver.removeListener('beeApiUrl', beeApiUrlListener)
       storeObserver.removeListener('beeDebugApiUrl', beeDebugApiUrlListener)
       storeObserver.removeListener('globalPostageBatch', globalPostageBatchListener)
       storeObserver.removeListener('globalPostageStampEnabled', globalPostageBatchEnabledListener)
+      storeObserver.removeListener('web2OriginEnabled', web2OriginEnableListener)
     }
   }, [])
 

--- a/src/popup-page/modules/app.tsx
+++ b/src/popup-page/modules/app.tsx
@@ -4,6 +4,7 @@ import { getItem } from '../../utils/storage'
 import { GlobalContext } from '../context/global'
 import { BeeApiUrlChangeForm } from './bee-api-url-change-form'
 import { PostageBatchElement } from './postage-batch-element'
+import { Web2Origin } from './web2-origin'
 
 export function App(): JSX.Element {
   const globalStateContext = useContext(GlobalContext)
@@ -17,6 +18,7 @@ export function App(): JSX.Element {
     const storedBeeDebugApiUrl = await getItem('beeDebugApiUrl')
     const storedGlobalPostageBatchId = await getItem('globalPostageBatch')
     const storedGlobalPostageBatchEnabled = await getItem('globalPostageStampEnabled')
+    const storedWeb2OriginEnabled = await getItem('web2OriginEnabled')
 
     if (storedBeeApiUrl) {
       changeGlobalState({ type: 'BEE_API_URL_SAVE', newValue: storedBeeApiUrl })
@@ -32,6 +34,10 @@ export function App(): JSX.Element {
 
     if (storedGlobalPostageBatchEnabled) {
       changeGlobalState({ type: 'GLOBAL_POSTAGE_BATCH_ENABLED_SAVE', newValue: storedGlobalPostageBatchEnabled })
+    }
+
+    if (storedWeb2OriginEnabled) {
+      changeGlobalState({ type: 'WEB2_ORIGIN_ENABLED_SAVE', newValue: storedWeb2OriginEnabled })
     }
   }
 
@@ -56,6 +62,7 @@ export function App(): JSX.Element {
               Open Bee Dashboard
             </a>
           </div>
+          <Web2Origin />
           <hr></hr>
           <PostageBatchElement />
         </div>

--- a/src/popup-page/modules/web2-origin.tsx
+++ b/src/popup-page/modules/web2-origin.tsx
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react'
+import { GlobalContext } from '../context/global'
+
+export function Web2Origin(): JSX.Element {
+  const globalStateContext = useContext(GlobalContext)
+  const { dispatch: dispatchGlobalState, state: globalState } = globalStateContext
+
+  const handleWeb2OriginClick = (): void => {
+    dispatchGlobalState({ type: 'WEB2_ORIGIN_ENABLED_SAVE', newValue: !globalState.web2OriginEnabled })
+  }
+
+  return (
+    <div id="form-bee-debug-api-url-change">
+      <label>
+        Enable Web2 origins for dApps (unsafe)
+        <input type="checkbox" checked={globalState.web2OriginEnabled} onClick={handleWeb2OriginClick} />
+      </label>
+    </div>
+  )
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events'
 interface Store {
   beeApiUrl: string
   beeDebugApiUrl: string
+  web2OriginEnabled: boolean
   globalPostageBatch: string | null
   globalPostageStampEnabled: boolean
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { BeeDebug } from '@ethersphere/bee-js'
+import { BeeDebug, DebugPostageBatch } from '@ethersphere/bee-js'
 import { ElementHandle, Page } from 'puppeteer'
 
 /**
@@ -61,11 +61,16 @@ export function bzzReferenceByGoogle(contentReference: string): string {
 
 export async function buyStamp(): Promise<string> {
   console.log(`Buying stamp on the Bee node ${BEE_DEBUG_API_URL}...`)
-  const bee = new BeeDebug(BEE_DEBUG_API_URL)
+  const beeDebug = new BeeDebug(BEE_DEBUG_API_URL)
 
-  const batchId = await bee.createPostageBatch('1', 20)
-  console.log('Waiting 11 secs for batch ID settlement...')
-  await new Promise(resolve => setTimeout(resolve, 11 * 1000))
+  const batchId = await beeDebug.createPostageBatch('1', 20)
+  let postageBatch: DebugPostageBatch
+  do {
+    postageBatch = await beeDebug.getPostageBatch(batchId)
+
+    console.log('Waiting 1 sec for batch ID settlement...')
+    await sleep()
+  } while (!postageBatch.usable)
 
   return batchId
 }
@@ -76,4 +81,8 @@ export function getStamp(): string {
   }
 
   return process.env.BEE_STAMP
+}
+
+function sleep(ms = 1000) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
This PR adds a configuration checkbox to the popup window that allows to turn off CSP headers on the Bee responses.

Some Web2 applications usage required this option.