### PR TITLE
fix: set global postage batch on fetch

### DIFF
--- a/src/popup-page/modules/GlobalPostageStamp.tsx
+++ b/src/popup-page/modules/GlobalPostageStamp.tsx
@@ -42,7 +42,12 @@ export default function GlobalPostageStamp(): ReactElement {
 
   const retrievePostageBatches = async () => {
     console.log('fetch postagethings')
-    setFetchedPostageBatches(await getPostageBatches(globalState.beeDebugApiUrl))
+    const postageBatches = await getPostageBatches(globalState.beeDebugApiUrl)
+    setFetchedPostageBatches(postageBatches)
+
+    if (!globalState.postageBatchId && postageBatches[0]) {
+      dispatchGlobalState({ type: 'GLOBAL_POSTAGE_BATCH_SAVE', newValue: postageBatches[0].batchID })
+    }
   }
 
   const getPostageBatchUsage = (): string => {


### PR DESCRIPTION
There was a problem in the UI logic when one enables the global postage batch usage and they have one stamp only, then the Extension won't set the postage stamp ID even if the UI shows it was set.