### PR TITLE
fix: global postage batch

### DIFF
--- a/src/popup-page/modules/GlobalPostageStamp.tsx
+++ b/src/popup-page/modules/GlobalPostageStamp.tsx
@@ -1,4 +1,4 @@
-import { PostageBatch } from '@ethersphere/bee-js'
+import { BatchId, PostageBatch } from '@ethersphere/bee-js'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import { createUseStyles } from 'react-jss'
 
@@ -44,8 +44,12 @@ export default function GlobalPostageStamp(): ReactElement {
     console.log('fetch postagethings')
     const postageBatches = await getPostageBatches(globalState.beeDebugApiUrl)
     setFetchedPostageBatches(postageBatches)
+    const batchIds = postageBatches.map(batch => batch.batchID)
 
-    if (!globalState.postageBatchId && postageBatches[0]) {
+    if (
+      (!globalState.postageBatchId || !batchIds.includes(globalState.postageBatchId as BatchId)) &&
+      postageBatches[0]
+    ) {
       dispatchGlobalState({ type: 'GLOBAL_POSTAGE_BATCH_SAVE', newValue: postageBatches[0].batchID })
     }
   }


### PR DESCRIPTION
when the user changed the bee client, the old saved global postage batch id remains in the config.
This PR fixes this problem.