### PR TITLE
ci: fix library publish script

### DIFF
--- a/.github/workflows/publish-lib.yaml
+++ b/.github/workflows/publish-lib.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Build
         run: npm run build --prefix library
 
+      - name: Npm login
+        run: npm login
+
       - name: Publish
         run: cd library && npm publish --access public && cd ..
         env:


### PR DESCRIPTION
Let's try if `npm login` can help with 404 error.